### PR TITLE
Use static list on command handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "chimera/foundation": "^0.4@dev",
-        "league/tactician": "^1.0",
-        "league/tactician-container": "^2.0"
+        "league/tactician": "^1.1",
+        "psr/container": "^1.0"
     },
     "provide": {
         "chimera/bus-implementation": "0.4.0"
@@ -31,11 +31,6 @@
     "config": {
         "preferred-install": "dist",
         "sort-packages": true
-    },
-    "extra": {
-        "unused": [
-            "league/tactician-container"
-        ]
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4698c6bfc8043e980eb52585505523e9",
+    "content-hash": "d40554d1c8470e7ae23c20fdb0d77bcf",
     "packages": [
         {
             "name": "brick/math",
@@ -126,25 +126,25 @@
         },
         {
             "name": "league/tactician",
-            "version": "v1.0.3",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/tactician.git",
-                "reference": "d0339e22fd9252fb0fa53102b488d2c514483b8a"
+                "reference": "e79f763170f3d5922ec29e85cffca0bac5cd8975"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/tactician/zipball/d0339e22fd9252fb0fa53102b488d2c514483b8a",
-                "reference": "d0339e22fd9252fb0fa53102b488d2c514483b8a",
+                "url": "https://api.github.com/repos/thephpleague/tactician/zipball/e79f763170f3d5922ec29e85cffca0bac5cd8975",
+                "reference": "e79f763170f3d5922ec29e85cffca0bac5cd8975",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "mockery/mockery": "~0.9",
-                "phpunit/phpunit": "^4.8.35",
-                "squizlabs/php_codesniffer": "~2.3"
+                "mockery/mockery": "^1.3",
+                "phpunit/phpunit": "^7.5.20 || ^9.3.8",
+                "squizlabs/php_codesniffer": "^3.5.8"
             },
             "type": "library",
             "extra": {
@@ -175,9 +175,9 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/tactician/issues",
-                "source": "https://github.com/thephpleague/tactician/tree/master"
+                "source": "https://github.com/thephpleague/tactician/tree/v1.1.0"
             },
-            "time": "2017-11-30T09:17:20+00:00"
+            "time": "2021-02-14T15:29:04+00:00"
         },
         {
             "name": "league/tactician-container",
@@ -458,7 +458,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -517,7 +517,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -1859,16 +1859,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.72",
+            "version": "0.12.78",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "ae32fb1c5e97979f424c3ccec4ee435a35754769"
+                "reference": "eecce8d2ee3cac6769f37b4cb1998b2715f82984"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ae32fb1c5e97979f424c3ccec4ee435a35754769",
-                "reference": "ae32fb1c5e97979f424c3ccec4ee435a35754769",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/eecce8d2ee3cac6769f37b4cb1998b2715f82984",
+                "reference": "eecce8d2ee3cac6769f37b4cb1998b2715f82984",
                 "shasum": ""
             },
             "require": {
@@ -1899,7 +1899,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.72"
+                "source": "https://github.com/phpstan/phpstan/tree/0.12.78"
             },
             "funding": [
                 {
@@ -1915,7 +1915,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-06T18:34:03+00:00"
+            "time": "2021-02-20T13:24:36+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -4034,16 +4034,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "267a9adeb8ecb8071040a740930e077cdfb987af"
+                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/267a9adeb8ecb8071040a740930e077cdfb987af",
-                "reference": "267a9adeb8ecb8071040a740930e077cdfb987af",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/5601e09b69f26c1828b13b6bb87cb07cddba3170",
+                "reference": "5601e09b69f26c1828b13b6bb87cb07cddba3170",
                 "shasum": ""
             },
             "require": {
@@ -4095,7 +4095,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -4111,20 +4111,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-01-22T09:19:47+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "6e971c891537eb617a00bb07a43d182a6915faba"
+                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/6e971c891537eb617a00bb07a43d182a6915faba",
-                "reference": "6e971c891537eb617a00bb07a43d182a6915faba",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/43a0283138253ed1d48d352ab6d0bdb3f809f248",
+                "reference": "43a0283138253ed1d48d352ab6d0bdb3f809f248",
                 "shasum": ""
             },
             "require": {
@@ -4179,7 +4179,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -4195,20 +4195,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T17:09:11+00:00"
+            "time": "2021-01-22T09:19:47+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "f377a3dd1fde44d37b9831d68dc8dea3ffd28e13"
+                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/f377a3dd1fde44d37b9831d68dc8dea3ffd28e13",
-                "reference": "f377a3dd1fde44d37b9831d68dc8dea3ffd28e13",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/5232de97ee3b75b0360528dae24e73db49566ab1",
+                "reference": "5232de97ee3b75b0360528dae24e73db49566ab1",
                 "shasum": ""
             },
             "require": {
@@ -4259,7 +4259,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -4275,11 +4275,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-01-22T09:19:47+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
@@ -4338,7 +4338,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -4358,7 +4358,7 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.22.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
@@ -4421,7 +4421,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.22.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.22.1"
             },
             "funding": [
                 {

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -7,5 +7,7 @@
     },
     "logs": {
         "text": "infection.log"
-    }
+    },
+    "minMsi": 100,
+    "minCoveredMsi": 100
 }

--- a/src/CommandHandler.php
+++ b/src/CommandHandler.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace Chimera\ServiceBus\Tactician;
+
+use League\Tactician\Exception\MissingHandlerException;
+use League\Tactician\Handler\Locator\HandlerLocator;
+use League\Tactician\Middleware;
+use Psr\Container\ContainerInterface;
+
+use function array_key_exists;
+use function assert;
+use function get_class;
+use function method_exists;
+
+final class CommandHandler implements Middleware, HandlerLocator
+{
+    private ContainerInterface $container;
+
+    /** @var array<string, array{service: string, method: string}> */
+    private array $handlers;
+
+    /** @param array<string, array{service: string, method: string}> $handlers */
+    public function __construct(ContainerInterface $container, array $handlers)
+    {
+        $this->container = $container;
+        $this->handlers  = $handlers;
+    }
+
+    /** @inheritdoc  */
+    // phpcs:ignore SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter
+    public function execute($command, callable $next)
+    {
+        $className = get_class($command);
+
+        $handler = $this->getHandlerForCommand($className);
+        $method  = $this->getMethodToCall($className);
+        assert(method_exists($handler, $method));
+
+        return $handler->$method($command); // @phpstan-ignore-line
+    }
+
+    /** @inheritdoc */
+    public function getHandlerForCommand($commandName): object
+    {
+        if (! array_key_exists($commandName, $this->handlers)) {
+            throw MissingHandlerException::forCommand($commandName);
+        }
+
+        return $this->container->get($this->handlers[$commandName]['service']);
+    }
+
+    private function getMethodToCall(string $commandName): string
+    {
+        assert(array_key_exists($commandName, $this->handlers));
+
+        return $this->handlers[$commandName]['method'];
+    }
+}

--- a/tests/CommandHandlerTest.php
+++ b/tests/CommandHandlerTest.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace Chimera\ServiceBus\Tactician\Tests;
+
+use Chimera\ServiceBus\Tactician\CommandHandler;
+use League\Tactician\Exception\MissingHandlerException;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+/** @coversDefaultClass \Chimera\ServiceBus\Tactician\CommandHandler */
+final class CommandHandlerTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::getHandlerForCommand
+     */
+    public function getHandlerForCommandShouldRaiseExceptionWhenNoHandlerWasRegistered(): void
+    {
+        $commandHandler = new CommandHandler(
+            $this->createMock(ContainerInterface::class),
+            []
+        );
+
+        $this->expectExceptionObject(MissingHandlerException::forCommand(FetchById::class));
+        $commandHandler->getHandlerForCommand(FetchById::class);
+    }
+
+    /**
+     * @test
+     *
+     * @covers ::__construct
+     * @covers ::execute
+     * @covers ::getHandlerForCommand
+     * @covers ::getMethodToCall
+     */
+    public function executeShouldCallTheRegisteredHandlerMethod(): void
+    {
+        $handler = new class {
+            public function testing(FetchById $query): string
+            {
+                return 'Here is the item #' . $query->id;
+            }
+        };
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects(self::once())->method('get')->with('handler')->willReturn($handler);
+
+        $commandHandler = new CommandHandler(
+            $container,
+            [FetchById::class => ['service' => 'handler', 'method' => 'testing']]
+        );
+
+        self::assertSame('Here is the item #1', $commandHandler->execute(new FetchById(1), 'is_string'));
+    }
+}


### PR DESCRIPTION
This provides a basic command handler that uses a static list of services/methods to find the handler to be called.

The inspiration comes from the changes done for Tactician v2 but we don't need to wait for its release.

More info:
- https://github.com/thephpleague/tactician/blob/master/src/Handler/CommandHandlerMiddleware.php
- https://github.com/thephpleague/tactician/blob/master/src/Handler/Mapping/MapByStaticList.php

